### PR TITLE
Added Throttling Warning to Readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.atomignore

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ providing bindings for all API functionality. Because it is intended to be
 pretty much identical, please consult [Jikan's
 documentation](https://jikan.docs.apiary.io/#) for thornier details on how it is meant to
 be used. Perhaps most importantly, Jikanpy does not make any attempts to rate
-limit itself, so use it as responsibly as you would use the API primitively. However,
+limit itself, so use it as responsibly as you would use the API primitively and
 remember that Jikan API has limitations, check out [this section](https://jikan.docs.apiary.io/#introduction/information/rate-limiting)
 of documentation in order to see to what extent the API is limited or throttled.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Jikanpy is a Python wrapper for [Jikan](https://github.com/jikan-me/jikan),
 providing bindings for all API functionality. Because it is intended to be
 pretty much identical, please consult [Jikan's
 documentation](https://jikan.docs.apiary.io/#) for thornier details on how it is meant to
-be used. Perhaps most importantly, Jikanpy does not make any attempts to rate
-limit itself, so use it as responsibly as you would use the API primitively.
+be used. Also, check out [this section](https://jikan.docs.apiary.io/#introduction/information/rate-limiting)
+of documentation in order to see to what extent the API is limited or throttled.
 
 ## Installation
 ```shell

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Jikanpy is a Python wrapper for [Jikan](https://github.com/jikan-me/jikan),
 providing bindings for all API functionality. Because it is intended to be
 pretty much identical, please consult [Jikan's
 documentation](https://jikan.docs.apiary.io/#) for thornier details on how it is meant to
-be used. Also, check out [this section](https://jikan.docs.apiary.io/#introduction/information/rate-limiting)
+be used. Perhaps most importantly, Jikanpy does not make any attempts to rate
+limit itself, so use it as responsibly as you would use the API primitively. However,
+remember that Jikan API has limitations, check out [this section](https://jikan.docs.apiary.io/#introduction/information/rate-limiting)
 of documentation in order to see to what extent the API is limited or throttled.
 
 ## Installation


### PR DESCRIPTION
Current readme says:

 > Jikanpy does not make any attempts to rate limit itself, so use it as responsibly as you would use the API primitively.

However, current Jikan API documentation clearly states that [it is throttled](https://jikan.docs.apiary.io/#introduction/information/rate-limiting).

Added this information to readme.