### PR TITLE
Added Codecov Feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,8 @@ jobs:
     install:
       - pip install -r requirements.txt
       - pip install -e .
+      - pip install pytest-cov codecov
     script: pytest
+    after_success:
+     - pytest --cov jikanpy tests/
+     - codecov

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Jikanpy
 =======
 
-[![Travis (.org)](https://img.shields.io/travis/AWConant/jikanpy.svg?style=flat-square)](https://travis-ci.org/AWConant/jikanpy) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+[![Travis (.org)](https://img.shields.io/travis/AWConant/jikanpy.svg?style=flat-square)](https://travis-ci.org/AWConant/jikanpy)
+[![Codecov](https://img.shields.io/codecov/c/github/AWConant/jikanpy.svg?style=flat-square)](https://codecov.io/gh/AWConant/jikanpy/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
 Jikanpy is a Python wrapper for [Jikan](https://github.com/jikan-me/jikan),
 providing bindings for all API functionality. Because it is intended to be


### PR DESCRIPTION
Related to #19.

# What's Changed?

I have added an `after_success` step to "Python 3.6" stage of Travis. As to why Python 3.6, it will be tested last and if it fails, the coverage will not be generated and sent to Codecov.

I have added a shields badge (with the same flat square style) to readme.

# How to Apply It?

 > #### Warning
 > All these steps had better be done before merging this PR, just in case.

First, @AWConant needs to create a Codecov account with the same username, preferably with Github login to Codecov which will autocreate and autosync repositories.

Then, @AWConant will need to add the repository to codecov. @AWConant might not see "Add Project" button, if it is the case, it is in "Profile" page, which is [this](https://codecov.io/gh/AWConant) when @AWConant creates a new account with the same name.

When he adds the repo to Codecov, he will see an environment variable which is called `CODECOV_TOKEN`. He should copy the content of this token.

Then, @AWConant will go to [Travis page of the project](https://travis-ci.org/AWConant/jikanpy). Click "More Options" and then settings as in the image below:

![Travis settings of project](https://user-images.githubusercontent.com/2399084/49615897-f6d4a180-f9bf-11e8-8ff2-5e6b509ab72f.png)

In the "Environment Variables" section, @AWConant will fill the form below:

![Travis settings environment variable form](https://user-images.githubusercontent.com/2399084/49615966-41561e00-f9c0-11e8-8579-ecc00fdc857a.png)

 - **Name** will be `CODECOV_TOKEN`.
 - **Value** will be the string that @AWConant has copied on Codecov project page.
 - **Display value in build log** is better off since @AWConant will not want to share this secret key.

Then, add it. My settings on forked repo seems like below:

![Travis settings environment variables section](https://user-images.githubusercontent.com/2399084/49616128-d822da80-f9c0-11e8-9de6-5db3abcaf31f.png)

Then, merge this PR.

The badge is already added and will appear on front page.