### PR TITLE
Modified examples, fixed top method error, and added tests

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -1,51 +1,52 @@
 from jikanpy import Jikan
+from pprint import pprint
 
 jikan = Jikan()
 
 mushishi = jikan.anime(457)
-print(mushishi)
+pprint(mushishi)
 
 fma = jikan.manga(25)
-print(fma)
+pprint(fma)
 
 ginko = jikan.character(425)
-print(ginko)
+pprint(ginko)
 
 kana_hanazawa = jikan.person(189)
-print(kana_hanazawa)
+pprint(kana_hanazawa)
 
 naruto = jikan.search(search_type='anime', query='naruto')
-print(naruto)
+pprint(naruto)
 
 winter_2018 = jikan.season(year=2018, season='winter')
-print(winter_2018)
+pprint(winter_2018)
 
 archive = jikan.season_archive()
-print(archive)
+pprint(archive)
 
 later = jikan.season_later()
-print(later)
+pprint(later)
 
 monday = jikan.schedule(day='monday')
-print(monday)
+pprint(monday)
 
 top_anime = jikan.top(type='anime')
-print(top_anime)
+pprint(top_anime)
 
 action = jikan.genre(type='anime', genre_id=1)
-print(action)
+pprint(action)
 
 deen = jikan.producer(producer_id=37)
-print(deen)
+pprint(deen)
 
 jump = jikan.magazine(magazine_id=83)
-print(jump)
+pprint(jump)
 
 nekomata1037 = jikan.user(username='Nekomata1037')
-print(nekomata1037)
+pprint(nekomata1037)
 
 fantasy_anime_league = jikan.club(379)
-print(fantasy_anime_league)
+pprint(fantasy_anime_league)
 
 meta = jikan.meta(request='requests', type='anime', period='today')
-print(meta)
+pprint(meta)

--- a/examplesasync.py
+++ b/examplesasync.py
@@ -1,53 +1,39 @@
 from jikanpy import AioJikan
 import asyncio
+from pprint import pprint
 
 loop = asyncio.get_event_loop()
 
 aio_jikan = AioJikan(loop=loop)
 
 
-@asyncio.coroutine
-def main(loop):
-    mushishi = yield from aio_jikan.anime(457)
-    print(mushishi)
+async def main(loop):
+    mushishi = await aio_jikan.anime(457)
+    pprint(mushishi)
 
-    fma = yield from aio_jikan.manga(25)
-    print(fma)
+    fma = await aio_jikan.manga(25)
+    pprint(fma)
 
-    ginko = yield from aio_jikan.character(425)
-    print(ginko)
+    ginko = await aio_jikan.character(425)
+    pprint(ginko)
 
-    naruto = yield from aio_jikan.search(search_type='anime', query='naruto')
-    print(naruto)
+    naruto = await aio_jikan.search(search_type='anime', query='naruto')
+    pprint(naruto)
 
-    winter_2018 = yield from aio_jikan.season(year=2018, season='winter')
-    print(winter_2018)
+    winter_2018 = await aio_jikan.season(year=2018, season='winter')
+    pprint(winter_2018)
 
-    monday = yield from aio_jikan.schedule(day='monday')
-    print(monday)
+    monday = await aio_jikan.schedule(day='monday')
+    pprint(monday)
 
-    top_anime = yield from aio_jikan.top(type='anime')
-    print(top_anime)
+    top_anime = await aio_jikan.top(type='anime')
+    pprint(top_anime)
 
-    meta = yield from aio_jikan.meta(request='requests', type='anime', period='today')
-    print(meta)
+    meta = await aio_jikan.meta(request='requests', type='anime', period='today')
+    pprint(meta)
 
     # Close the connection to Jikan API
-    yield from aio_jikan.close()
+    await aio_jikan.close()
 
 
 loop.run_until_complete(main(loop))
-
-# Using async/await syntax (only supported in Python 3.5+)
-#
-# async def main(loop):
-#     mushishi = await aio_jikan.anime(457)
-#     print(mushishi)
-
-#     fma = await aio_jikan.manga(25)
-#     print(fma)
-
-#     # Close the connection to Jikan API
-#     await aio_jikan.close()
-
-# loop.run_until_complete(main(loop))

--- a/jikanpy/abstractjikan.py
+++ b/jikanpy/abstractjikan.py
@@ -104,6 +104,8 @@ class AbstractJikan(ABC):
         url = self._add_page_to_url(url, page)
         # Check if subtype is valid
         if subtype is not None:
+            if page is None:
+                raise ClientException('Page is required if subtype is given')
             if subtype.lower() not in SUBTYPES[type.lower()]:
                 raise ClientException('Subtype is not valid for ' + type)
             url += '/' + subtype.lower()

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -6,6 +6,7 @@ YEAR = 2018
 SEASON = 'winter'
 DAY = 'monday'
 TYPE = 'anime'
+SUBTYPE = 'tv'
 GENRE = 1
 PRODUCER = 37
 MAGAZINE = 83

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -14,6 +14,18 @@ def anime_keys():
 
 
 @pytest.fixture
+def anime_episodes_keys():
+    return {'request_hash', 'request_cached', 'request_cache_expiry',
+            'episodes_last_page', 'episodes'}
+
+
+@pytest.fixture
+def episode_keys():
+    return {'episode_id', 'title', 'title_japanese', 'title_romanji', 'aired',
+            'filler', 'recap', 'video_url', 'forum_url'}
+
+
+@pytest.fixture
 def manga_keys():
     return {'request_hash', 'request_cached', 'request_cache_expiry', 'mal_id',
             'url', 'title', 'title_english', 'title_synonyms', 'title_japanese',
@@ -123,6 +135,12 @@ def user_keys():
             'username', 'url', 'image_url', 'last_online', 'gender', 'birthday',
             'location', 'joined', 'anime_stats', 'manga_stats', 'favorites',
             'about'}
+
+
+@pytest.fixture
+def animelist_keys():
+    return {'request_hash', 'request_cached', 'request_cache_expiry', 'anime'}
+
 
 @pytest.fixture
 def club_keys():

--- a/tests/test_aiojikan.py
+++ b/tests/test_aiojikan.py
@@ -9,67 +9,77 @@ from jikanpy.exceptions import APIException, ClientException, DeprecatedEndpoint
 from constants import *
 from fixtures import *
 
+pytestmark = pytest.mark.asyncio
+
 
 @pytest.fixture
 def aio_jikan(event_loop):
     return AioJikan(loop=event_loop)
 
+
 @vcr.use_cassette('tests/vcr_cassettes/aio-anime-success.yaml')
-@pytest.mark.asyncio
 async def test_anime_success(anime_keys, aio_jikan):
     anime_info = await aio_jikan.anime(MUSHISHI_ID)
 
     assert isinstance(anime_info, dict)
     assert anime_info['title'] == 'Mushishi'
     assert anime_keys.issubset(anime_info.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-anime-episodes-success.yaml')
+async def test_anime_episodes_success(anime_episodes_keys, episode_keys, aio_jikan):
+    anime_episodes_info = await aio_jikan.anime(
+        MUSHISHI_ID, extension='episodes', page=1)
+
+    assert isinstance(anime_episodes_info, dict)
+    assert isinstance(anime_episodes_info['episodes'], list)
+    for episode in anime_episodes_info['episodes']:
+        assert episode_keys.issubset(episode.keys())
+    assert anime_episodes_keys.issubset(anime_episodes_info.keys())
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-manga-success.yaml')
-@pytest.mark.asyncio
 async def test_manga_success(manga_keys, aio_jikan):
     manga_info = await aio_jikan.manga(FULLMETAL_ID)
 
     assert isinstance(manga_info, dict)
     assert manga_info['title'] == 'Fullmetal Alchemist'
     assert manga_keys.issubset(manga_info.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-character-success.yaml')
-@pytest.mark.asyncio
 async def test_character_success(character_keys, aio_jikan):
     character_info = await aio_jikan.character(GINKO_ID)
 
     assert isinstance(character_info, dict)
     assert character_info['name'] == 'Ginko'
     assert character_keys.issubset(character_info.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-person-success.yaml')
-@pytest.mark.asyncio
 async def test_person_success(person_keys, aio_jikan):
     person_info = await aio_jikan.person(KANA_HANAZAWA_ID)
 
     assert isinstance(person_info, dict)
     assert person_info['name'] == 'Kana Hanazawa'
     assert person_keys.issubset(person_info.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-search-success.yaml')
-@pytest.mark.asyncio
 async def test_search_success(search_keys, aio_jikan):
-    search_info = await aio_jikan.search(search_type='anime', query='naruto')
+    search_info = await aio_jikan.search(
+        search_type='anime', query='naruto', parameters={'type': 'tv'})
 
     assert isinstance(search_info, dict)
     assert search_keys.issubset(search_info.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-season-success.yaml')
-@pytest.mark.asyncio
 async def test_season_success(season_keys, seasonal_anime_keys, aio_jikan):
     season_info = await aio_jikan.season(year=YEAR, season=SEASON)
 
@@ -77,11 +87,10 @@ async def test_season_success(season_keys, seasonal_anime_keys, aio_jikan):
     assert season_keys.issubset(season_info.keys())
     for anime in season_info['anime']:
         assert seasonal_anime_keys.issubset(anime.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-season-archive-success.yaml')
-@pytest.mark.asyncio
 async def test_season_archive_success(season_archive_keys, archived_years_keys, aio_jikan):
     season_archive_info = await aio_jikan.season_archive()
 
@@ -91,11 +100,10 @@ async def test_season_archive_success(season_archive_keys, archived_years_keys, 
         assert archived_years_keys.issubset(year_info.keys())
         assert isinstance(year_info['year'], int)
         assert isinstance(year_info['seasons'], list)
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-season-later-success.yaml')
-@pytest.mark.asyncio
 async def test_season_later_success(season_keys, seasonal_anime_keys, aio_jikan):
     season_later_info = await aio_jikan.season_later()
 
@@ -103,11 +111,10 @@ async def test_season_later_success(season_keys, seasonal_anime_keys, aio_jikan)
     assert season_keys.issubset(season_later_info.keys())
     for anime in season_later_info['anime']:
         assert seasonal_anime_keys.issubset(anime.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-schedule-success.yaml')
-@pytest.mark.asyncio
 async def test_schedule_success(schedule_keys, subset_anime_keys, aio_jikan):
     schedule_info = await aio_jikan.schedule(day=DAY)
 
@@ -116,23 +123,21 @@ async def test_schedule_success(schedule_keys, subset_anime_keys, aio_jikan):
     assert DAY.lower() in schedule_info
     for anime in schedule_info[DAY]:
         assert subset_anime_keys.issubset(anime.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-top-success.yaml')
-@pytest.mark.asyncio
 async def test_top_success(top_keys, top_anime_keys, aio_jikan):
-    top_info = await aio_jikan.top(type=TYPE)
+    top_info = await aio_jikan.top(type=TYPE, page=1, subtype=SUBTYPE)
 
     assert isinstance(top_info, dict)
     assert top_keys.issubset(top_info.keys())
     for anime in top_info['top']:
         assert top_anime_keys.issubset(anime.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-genre-success.yaml')
-@pytest.mark.asyncio
 async def test_genre_success(genre_keys, subset_anime_keys, aio_jikan):
     genre_info = await aio_jikan.genre(type=TYPE, genre_id=GENRE)
 
@@ -140,11 +145,10 @@ async def test_genre_success(genre_keys, subset_anime_keys, aio_jikan):
     assert genre_keys.issubset(genre_info.keys())
     for anime in genre_info['anime']:
         assert subset_anime_keys.issubset(anime.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-producer-success.yaml')
-@pytest.mark.asyncio
 async def test_producer_success(producer_keys, subset_anime_keys, aio_jikan):
     producer_info = await aio_jikan.producer(producer_id=PRODUCER)
 
@@ -152,11 +156,10 @@ async def test_producer_success(producer_keys, subset_anime_keys, aio_jikan):
     assert producer_keys.issubset(producer_info.keys())
     for anime in producer_info['anime']:
         assert subset_anime_keys.issubset(anime.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-magazine-success.yaml')
-@pytest.mark.asyncio
 async def test_magazine_success(magazine_keys, magazine_manga_keys, aio_jikan):
     magazine_info = await aio_jikan.magazine(magazine_id=MAGAZINE)
 
@@ -164,11 +167,10 @@ async def test_magazine_success(magazine_keys, magazine_manga_keys, aio_jikan):
     assert magazine_keys.issubset(magazine_info.keys())
     for manga in magazine_info['manga']:
         assert magazine_manga_keys.issubset(manga.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-user-success.yaml')
-@pytest.mark.asyncio
 async def test_user_success(user_keys, aio_jikan):
     user_info = await aio_jikan.user(username=USERNAME)
 
@@ -176,128 +178,221 @@ async def test_user_success(user_keys, aio_jikan):
     assert user_info['username'] == 'Nekomata1037'
     assert user_info['gender'] == 'Male'
     assert user_keys.issubset(user_info.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-animelist-success.yaml')
+async def test_animelist_success(animelist_keys, aio_jikan):
+    animelist_info = await aio_jikan.user(username=USERNAME, request='animelist')
+
+    assert isinstance(animelist_info, dict)
+    assert animelist_keys.issubset(animelist_info.keys())
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-club-success.yaml')
-@pytest.mark.asyncio
 async def test_club_success(club_keys, aio_jikan):
     club_info = await aio_jikan.club(CLUB_ID)
 
     assert isinstance(club_info, dict)
     assert club_info['title'] == 'Fantasy Anime League'
     assert club_keys.issubset(club_info.keys())
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-meta-success.yaml')
-@pytest.mark.asyncio
 async def test_meta_success(aio_jikan):
     meta_info = await aio_jikan.meta(request='requests', type='anime', period='today')
 
     assert isinstance(meta_info, dict)
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-anime-failure.yaml')
-@pytest.mark.asyncio
 async def test_anime_failure(aio_jikan):
     with pytest.raises(APIException):
         await aio_jikan.anime(-1)
-    aio_jikan.close()
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-anime-extension-failure.yaml')
+async def test_anime_extension_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.anime(MUSHISHI_ID, extension='x')
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-manga-failure.yaml')
-@pytest.mark.asyncio
 async def test_manga_failure(aio_jikan):
     with pytest.raises(APIException):
         await aio_jikan.manga(-1)
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-character-failure.yaml')
-@pytest.mark.asyncio
 async def test_character_failure(aio_jikan):
     with pytest.raises(APIException):
         await aio_jikan.character(-1)
-    aio_jikan.close()
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-search-key-failure.yaml')
+async def test_search_key_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.search(search_type='anime', query='naruto', parameters={'x': 'tv'})
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-search-value-failure.yaml')
+async def test_search_value_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.search(search_type='anime', query='naruto', parameters={'type': 'x'})
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-season-failure.yaml')
-@pytest.mark.asyncio
 async def test_season_failure(aio_jikan):
     with pytest.raises(APIException):
         await aio_jikan.season(year=-1, season=SEASON)
-    aio_jikan.close()
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-season-client-failure.yaml')
+async def test_season_client_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.season(year='x', season=SEASON)
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-schedule-failure.yaml')
-@pytest.mark.asyncio
 async def test_schedule_failure(aio_jikan):
     with pytest.raises(ClientException):
         await aio_jikan.schedule(day='x')
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-top-failure.yaml')
-@pytest.mark.asyncio
 async def test_top_failure(aio_jikan):
     with pytest.raises(ClientException):
         await aio_jikan.top(type='x')
-    aio_jikan.close()
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-top-subtype-failure.yaml')
+async def test_top_subtype_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.top(type=TYPE, page=1, subtype='x')
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-top-page-failure.yaml')
+async def test_top_page_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.top(type=TYPE, subtype=SUBTYPE)
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-genre-failure.yaml')
-@pytest.mark.asyncio
 async def test_genre_failure(aio_jikan):
     with pytest.raises(ClientException):
-        await aio_jikan.genre(type='x', genre_id=1)
-    aio_jikan.close()
+        await aio_jikan.genre(type='x', genre_id=GENRE)
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-genre-id-failure.yaml')
+async def test_genre_id_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.genre(type=TYPE, genre_id='x')
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-producer-failure.yaml')
-@pytest.mark.asyncio
 async def test_producer_failure(aio_jikan):
     with pytest.raises(ClientException):
         await aio_jikan.producer(producer_id='producer')
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-magazine-failure.yaml')
-@pytest.mark.asyncio
 async def test_magazine_failure(aio_jikan):
     with pytest.raises(ClientException):
         await aio_jikan.magazine(magazine_id='magazine')
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-user-failure.yaml')
-@pytest.mark.asyncio
 async def test_user_failure(aio_jikan):
     with pytest.raises(ClientException):
         await aio_jikan.user(username='user', request='friends', argument='x')
-    aio_jikan.close()
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-user-request-failure.yaml')
+async def test_user_request_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.user(username='user', request='x', argument='x')
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-user-profile-failure.yaml')
+async def test_user_profile_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.user(username='user', request='profile', argument='x')
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-user-animelist-failure.yaml')
+async def test_user_animelist_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.user(username='user', request='animelist', page=1)
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-user-history-failure.yaml')
+async def test_user_history_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.user(username='user', request='history', argument='x')
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-user-animelist-argument-failure.yaml')
+async def test_user_animelist_argument_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.user(username='user', request='animelist', argument='x')
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-user-mangalist-argument-failure.yaml')
+async def test_user_mangalist_argument_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.user(username='user', request='mangalist', argument='x')
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-club-failure.yaml')
-@pytest.mark.asyncio
 async def test_club_failure(aio_jikan):
     with pytest.raises(APIException):
         await aio_jikan.club(-1)
-    aio_jikan.close()
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-meta-failure.yaml')
-@pytest.mark.asyncio
 async def test_meta_failure(aio_jikan):
     with pytest.raises(ClientException):
         await aio_jikan.meta(request='x', type='x', period='x')
-    aio_jikan.close()
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-meta-type-failure.yaml')
+async def test_meta_type_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.meta(request='requests', type='x', period='x')
+    await aio_jikan.close()
+
+
+@vcr.use_cassette('tests/vcr_cassettes/aio-meta-period-failure.yaml')
+async def test_meta_period_failure(aio_jikan):
+    with pytest.raises(ClientException):
+        await aio_jikan.meta(request='requests', type='anime', period='x')
+    await aio_jikan.close()
 
 
 @vcr.use_cassette('tests/vcr_cassettes/aio-user-list-failure.yaml')
-@pytest.mark.asyncio
 async def test_user_list_failure(aio_jikan):
     with pytest.raises(DeprecatedEndpoint):
         await aio_jikan.user_list(1)
-    aio_jikan.close()
+    await aio_jikan.close()

--- a/tests/test_jikan.py
+++ b/tests/test_jikan.py
@@ -22,6 +22,18 @@ def test_anime_success(anime_keys, jikan):
     assert anime_keys.issubset(anime_info.keys())
 
 
+@vcr.use_cassette('tests/vcr_cassettes/anime-episodes-success.yaml')
+def test_anime_episodes_success(anime_episodes_keys, episode_keys, jikan):
+    anime_episodes_info = jikan.anime(
+        MUSHISHI_ID, extension='episodes', page=1)
+
+    assert isinstance(anime_episodes_info, dict)
+    assert isinstance(anime_episodes_info['episodes'], list)
+    for episode in anime_episodes_info['episodes']:
+        assert episode_keys.issubset(episode.keys())
+    assert anime_episodes_keys.issubset(anime_episodes_info.keys())
+
+
 @vcr.use_cassette('tests/vcr_cassettes/manga-success.yaml')
 def test_manga_success(manga_keys, jikan):
     manga_info = jikan.manga(FULLMETAL_ID)
@@ -51,7 +63,8 @@ def test_person_success(person_keys, jikan):
 
 @vcr.use_cassette('tests/vcr_cassettes/search-success.yaml')
 def test_search_success(search_keys, jikan):
-    search_info = jikan.search(search_type='anime', query='naruto')
+    search_info = jikan.search(
+        search_type='anime', query='naruto', parameters={'type': 'tv'})
 
     assert isinstance(search_info, dict)
     assert search_keys.issubset(search_info.keys())
@@ -102,7 +115,7 @@ def test_schedule_success(schedule_keys, subset_anime_keys, jikan):
 
 @vcr.use_cassette('tests/vcr_cassettes/top-success.yaml')
 def test_top_success(top_keys, top_anime_keys, jikan):
-    top_info = jikan.top(type=TYPE)
+    top_info = jikan.top(type=TYPE, page=1, subtype=SUBTYPE)
 
     assert isinstance(top_info, dict)
     assert top_keys.issubset(top_info.keys())
@@ -150,6 +163,14 @@ def test_user_success(user_keys, jikan):
     assert user_keys.issubset(user_info.keys())
 
 
+@vcr.use_cassette('tests/vcr_cassettes/animelist-success.yaml')
+def test_animelist_success(animelist_keys, jikan):
+    animelist_info = jikan.user(username=USERNAME, request='animelist')
+
+    assert isinstance(animelist_info, dict)
+    assert animelist_keys.issubset(animelist_info.keys())
+
+
 @vcr.use_cassette('tests/vcr_cassettes/club-success.yaml')
 def test_club_success(club_keys, jikan):
     club_info = jikan.club(CLUB_ID)
@@ -172,6 +193,12 @@ def test_anime_failure(jikan):
         jikan.anime(-1)
 
 
+@vcr.use_cassette('tests/vcr_cassettes/anime-extension-failure.yaml')
+def test_anime_extension_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.anime(MUSHISHI_ID, extension='x')
+
+
 @vcr.use_cassette('tests/vcr_cassettes/manga-failure.yaml')
 def test_manga_failure(jikan):
     with pytest.raises(APIException):
@@ -184,10 +211,30 @@ def test_character_failure(jikan):
         jikan.character(-1)
 
 
+@vcr.use_cassette('tests/vcr_cassettes/search-key-failure.yaml')
+def test_search_key_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.search(search_type='anime', query='naruto',
+                     parameters={'x': 'tv'})
+
+
+@vcr.use_cassette('tests/vcr_cassettes/search-value-failure.yaml')
+def test_search_value_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.search(search_type='anime', query='naruto',
+                     parameters={'type': 'x'})
+
+
 @vcr.use_cassette('tests/vcr_cassettes/season-failure.yaml')
 def test_season_failure(jikan):
     with pytest.raises(APIException):
         jikan.season(year=-1, season=SEASON)
+
+
+@vcr.use_cassette('tests/vcr_cassettes/season-client-failure.yaml')
+def test_season_client_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.season(year='x', season=SEASON)
 
 
 @vcr.use_cassette('tests/vcr_cassettes/schedule-failure.yaml')
@@ -202,10 +249,28 @@ def test_top_failure(jikan):
         jikan.top(type='x')
 
 
+@vcr.use_cassette('tests/vcr_cassettes/top-subtype-failure.yaml')
+def test_top_subtype_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.top(type=TYPE, page=1, subtype='x')
+
+
+@vcr.use_cassette('tests/vcr_cassettes/top-page-failure.yaml')
+def test_top_page_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.top(type=TYPE, subtype=SUBTYPE)
+
+
 @vcr.use_cassette('tests/vcr_cassettes/genre-failure.yaml')
 def test_genre_failure(jikan):
     with pytest.raises(ClientException):
-        jikan.genre(type='x', genre_id=1)
+        jikan.genre(type='x', genre_id=GENRE)
+
+
+@vcr.use_cassette('tests/vcr_cassettes/genre-id-failure.yaml')
+def test_genre_id_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.genre(type=TYPE, genre_id='x')
 
 
 @vcr.use_cassette('tests/vcr_cassettes/producer-failure.yaml')
@@ -226,6 +291,42 @@ def test_user_failure(jikan):
         jikan.user(username='user', request='friends', argument='x')
 
 
+@vcr.use_cassette('tests/vcr_cassettes/user-request-failure.yaml')
+def test_user_request_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.user(username='user', request='x', argument='x')
+
+
+@vcr.use_cassette('tests/vcr_cassettes/user-profile-failure.yaml')
+def test_user_profile_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.user(username='user', request='profile', argument='x')
+
+
+@vcr.use_cassette('tests/vcr_cassettes/user-animelist-failure.yaml')
+def test_user_animelist_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.user(username='user', request='animelist', page=1)
+
+
+@vcr.use_cassette('tests/vcr_cassettes/user-history-failure.yaml')
+def test_user_history_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.user(username='user', request='history', argument='x')
+
+
+@vcr.use_cassette('tests/vcr_cassettes/user-animelist-argument-failure.yaml')
+def test_user_animelist_argument_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.user(username='user', request='animelist', argument='x')
+
+
+@vcr.use_cassette('tests/vcr_cassettes/user-mangalist-argument-failure.yaml')
+def test_user_mangalist_argument_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.user(username='user', request='mangalist', argument='x')
+
+
 @vcr.use_cassette('tests/vcr_cassettes/club-failure.yaml')
 def test_club_failure(jikan):
     with pytest.raises(APIException):
@@ -236,6 +337,18 @@ def test_club_failure(jikan):
 def test_meta_failure(jikan):
     with pytest.raises(ClientException):
         jikan.meta(request='x', type='x', period='x')
+
+
+@vcr.use_cassette('tests/vcr_cassettes/meta-type-failure.yaml')
+def test_meta_type_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.meta(request='requests', type='x', period='x')
+
+
+@vcr.use_cassette('tests/vcr_cassettes/meta-period-failure.yaml')
+def test_meta_period_failure(jikan):
+    with pytest.raises(ClientException):
+        jikan.meta(request='requests', type='anime', period='x')
 
 
 @vcr.use_cassette('tests/vcr_cassettes/user-list-failure.yaml')


### PR DESCRIPTION
- Added pprint to examples
- Replaced asyncio.coroutine with async/await syntax in async examples (no more 3.4 support)
- Added error if subtype given without page for top method
- Added tests to improve coverage