### PR TITLE
add examples for 'argument' and 'page' positional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ nekomata1037 = jikan.user(username='Nekomata1037', request='history')
 nekomata1037 = jikan.user(username='Nekomata1037', request='animelist')
 nekomata1037 = jikan.user(username='Nekomata1037', request='animelist', argument='completed', page=2)
 # manga list
-nekomata1037 = jikan.user(username='Nekomata1037', request='mangalist')
-nekomata1037 = jikan.user(username='Nekomata1037', request='mangalist', argument='all')
+Xinil = jikan.user(username='Xinil', request='mangalist')
+Xinil = jikan.user(username='Xinil', request='mangalist', argument='all')
 
 # clubs
 fantasy_anime_league = jikan.club(379)

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ nekomata1037 = jikan.user(username='Nekomata1037', request='history')
 nekomata1037 = jikan.user(username='Nekomata1037', request='animelist')
 nekomata1037 = jikan.user(username='Nekomata1037', request='animelist', argument='completed', page=2)
 # manga list
-Xinil = jikan.user(username='Xinil', request='mangalist')
-Xinil = jikan.user(username='Xinil', request='mangalist', argument='all')
+xinil = jikan.user(username='Xinil', request='mangalist')
+xinil = jikan.user(username='Xinil', request='mangalist', argument='all')
 
 # clubs
 fantasy_anime_league = jikan.club(379)

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ nekomata1037 = jikan.user(username='Nekomata1037', request='friends')
 nekomata1037 = jikan.user(username='Nekomata1037', request='history')
 # anime list
 nekomata1037 = jikan.user(username='Nekomata1037', request='animelist')
+nekomata1037 = jikan.user(username='Nekomata1037', request='animelist', argument='completed', page=2)
 # manga list
 nekomata1037 = jikan.user(username='Nekomata1037', request='mangalist')
+nekomata1037 = jikan.user(username='Nekomata1037', request='mangalist', argument='all')
 
 # clubs
 fantasy_anime_league = jikan.club(379)


### PR DESCRIPTION
It wasn't clear on first glance how to provide the `argument` positional argument for user lists requests, I thought adding some examples might be helpful.

One could infer based on the other examples on the [README.md](https://github.com/AWConant/jikanpy/blob/master/README.md) that `page` would work for user lists, but it helps to be explicit, especially since there's no mention that user lists are paginated.

I also wanted to mention that while there's no syntatic issue with these lines:

```
nekomata1037 = jikan.user(username='Nekomata1037', request='mangalist')
nekomata1037 = jikan.user(username='Nekomata1037', request='mangalist', argument='all')
```

Since [Nekomata1037](https://myanimelist.net/profile/nekomata1037/) has his manga list as "Access to this list has been restricted by the owner.", those return an `APIException`. 

Let me know if thats something you want to edit/whether I should change that to someone else (say [Xinil](https://myanimelist.net/profile/xinil/)) in this PR or another one.

Thanks for your work on the wrapper, its very useful!