### PR TITLE
allow users to pass a base url to Jikan

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ requests = jikan.meta(request='requests', type='anime', period='today')
 status = jikan.meta(request='status', type='anime', period='today')
 ```
 
+If you're running an instance of [jikan-rest](https://github.com/jikan-me/jikan-rest) on your system, and want to use that instead of [api.jikan.moe](https://jikan.moe/), you can pass that to Jikan:
+
+```python
+from jikanpy import Jikan
+jikan = Jikan("http://localhost:8000/v3/")
+```
+
 ## Async Usage (Python 3.5+)
 ```python
 from jikanpy import AioJikan

--- a/jikanpy/abstractjikan.py
+++ b/jikanpy/abstractjikan.py
@@ -17,8 +17,9 @@ class AbstractJikan(ABC):
     so use it responsibly.
     """
 
-    def __init__(self, use_ssl=True):
-        selected_base = BASE_URL_SSL if use_ssl else BASE_URL
+    def __init__(self, selected_base=None, use_ssl=True):
+        if selected_base is None:
+            selected_base = BASE_URL_SSL if use_ssl else BASE_URL
         self.base = selected_base + '{endpoint}/{id}'
         self.search_base = selected_base + 'search/{search_type}?q={query}'
         self.season_base = selected_base + 'season/{year}/{season}'


### PR DESCRIPTION
this could be used while hosting a [jikan-rest](https://github.com/jikan-me/jikan-rest) instance locally:

```
import jikanpy
jikanpy.Jikan("http://localhost:8000/v3/")
```