### PR TITLE
Wrap response

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ limit itself, so use it as responsibly as you would use the API primitively and
 remember that Jikan API has limitations, check out [this section](https://jikan.docs.apiary.io/#introduction/information/rate-limiting)
 of documentation in order to see to what extent the API is limited or throttled.
 
+In addition to the typical response from the API, each response contains two additional fields:
+
+* `jikan_url`: The URL that was requested; for example: `https://api.jikan.moe/v3/anime/1`.
+* `headers`: The response headers from Jikan, detailed [here](https://jikan.docs.apiary.io/#introduction/information/caching).
+
 ## Installation
 ```shell
 $ pip install git+git://github.com/AWConant/jikanpy.git

--- a/jikanpy/abstractjikan.py
+++ b/jikanpy/abstractjikan.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import Mapping, Dict, Optional, Union, Any
 
+import requests
+import aiohttp
+
 from jikanpy.exceptions import APIException, ClientException, DeprecatedEndpoint
 from jikanpy.parameters import (
     EXTENSIONS,
@@ -72,7 +75,7 @@ class AbstractJikan(ABC):
 
     def _add_jikan_metadata(
         self,
-        response: Any,  # Union[requests.Response, aiohttp.ClientResponse]
+        response: Union[requests.Response, aiohttp.ClientResponse],
         response_dict: Dict,
         url: str
     ) -> Dict:
@@ -84,7 +87,7 @@ class AbstractJikan(ABC):
     @abstractmethod
     def _wrap_response(
         self,
-        response: Any,
+        response: Any,  # Union[requests.Response, aiohttp.ClientResponse
         url: str,
         **kwargs: Union[int, Optional[str]]
     ) -> Dict:

--- a/jikanpy/abstractjikan.py
+++ b/jikanpy/abstractjikan.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from typing import Mapping, Dict, Optional, Union, Any
-import json
 
 from jikanpy.exceptions import APIException, ClientException, DeprecatedEndpoint
 from jikanpy.parameters import (
@@ -51,24 +50,45 @@ class AbstractJikan(ABC):
         self.season_later_url: str = selected_base + "season/later"
 
     def _check_response(
-        self, response: Any, **kwargs: Union[int, Optional[str]]
+        self,
+        response_dict: Dict,
+        response_status_code: int,
+        **kwargs: Union[int, Optional[str]]
     ) -> None:
         """
         Check if the response is an error
 
         Keyword Arguments:
-        response -- response from the API call
+        response_dict -- parsed response from the API call
+                         is empty ({}) when there was a json.decoder.JSONDecodeError
+        response_status -- the corresponding http code for the response
         kwargs -- keyword arguments
         """
-        if response.status_code >= 400:
-            try:
-                json_resp = response.json()
-                error_msg = json_resp.get("error")
-            except json.decoder.JSONDecodeError:
-                error_msg = ""
-            err_str: str = "{} {}: error for ".format(response.status_code, error_msg)
+        if response_status_code >= 400:
+            error_msg = response_dict.get("error", "")
+            err_str: str = "{} {}: error for ".format(response_status_code, error_msg)
             err_str += ", ".join("=".join((str(k), str(v))) for k, v in kwargs.items())
             raise APIException(err_str)
+
+    def _add_jikan_metadata(
+        self,
+        response: Any,  # Union[requests.Response, aiohttp.ClientResponse]
+        response_dict: Dict,
+        url: str
+    ) -> Dict:
+        response_dict["jikan_url"] = url
+        response_dict["headers"] = dict(response.headers)  # converts from CIMultiDictProxy for aiohttp.ClientResponse
+        return response_dict
+
+    @abstractmethod
+    def _wrap_response(
+        self,
+        response: Any,
+        url: str,
+        **kwargs: Union[int, Optional[str]]
+    ) -> Dict:
+        """Parses the response as json, then runs _check_response and _add_jikan_metadata"""
+        raise NotImplementedError
 
     def _get_url(
         self, endpoint: str, id: int, extension: Optional[str], page: Optional[int]

--- a/jikanpy/abstractjikan.py
+++ b/jikanpy/abstractjikan.py
@@ -76,6 +76,7 @@ class AbstractJikan(ABC):
         response_dict: Dict,
         url: str
     ) -> Dict:
+        """Adds the response headers and jikan endpoint url to response dictionary"""
         response_dict["jikan_url"] = url
         response_dict["headers"] = dict(response.headers)  # converts from CIMultiDictProxy for aiohttp.ClientResponse
         return response_dict

--- a/jikanpy/abstractjikan.py
+++ b/jikanpy/abstractjikan.py
@@ -56,7 +56,7 @@ class AbstractJikan(ABC):
         self,
         response_dict: Dict,
         response_status_code: int,
-        **kwargs: Union[int, Optional[str]]
+        **kwargs: Union[int, Optional[str]],
     ) -> None:
         """
         Check if the response is an error
@@ -77,11 +77,12 @@ class AbstractJikan(ABC):
         self,
         response: Union[requests.Response, aiohttp.ClientResponse],
         response_dict: Dict,
-        url: str
+        url: str,
     ) -> Dict:
         """Adds the response headers and jikan endpoint url to response dictionary"""
         response_dict["jikan_url"] = url
-        response_dict["headers"] = dict(response.headers)  # converts from CIMultiDictProxy for aiohttp.ClientResponse
+        # dict() is to convert from CIMultiDictProxy for aiohttp.ClientResponse
+        response_dict["headers"] = dict(response.headers)
         return response_dict
 
     @abstractmethod
@@ -89,7 +90,7 @@ class AbstractJikan(ABC):
         self,
         response: Any,  # Union[requests.Response, aiohttp.ClientResponse
         url: str,
-        **kwargs: Union[int, Optional[str]]
+        **kwargs: Union[int, Optional[str]],
     ) -> Dict:
         """Parses the response as json, then runs _check_response and _add_jikan_metadata"""
         raise NotImplementedError

--- a/jikanpy/aiojikan.py
+++ b/jikanpy/aiojikan.py
@@ -1,11 +1,10 @@
-from typing import Optional, Dict, Any, Mapping, Union
 import json
+from typing import Optional, Dict, Any, Mapping, Union
 
 import aiohttp
 import asyncio
 
 from jikanpy.abstractjikan import AbstractJikan
-from jikanpy.exceptions import APIException
 
 
 class AioJikan(AbstractJikan):
@@ -24,19 +23,19 @@ class AioJikan(AbstractJikan):
             aiohttp.ClientSession(loop=self.loop) if session is None else session
         )
 
-    async def _check_response(  # type: ignore
-        self, response: Any, **kwargs: Union[int, Optional[str]]
-    ) -> None:
-        """Overrides _check_response in AbstractJikan"""
-        if response.status >= 400:
-            try:
-                json_resp = await response.json()
-                error_msg = json_resp.get("error")
-            except json.decoder.JSONDecodeError:
-                error_msg = ""
-            err_str: str = "{} {}: error for ".format(response.status, error_msg)
-            err_str += ", ".join("=".join((str(k), str(v))) for k, v in kwargs.items())
-            raise APIException(err_str)
+    async def _wrap_response( # type: ignore
+        self,
+        response: aiohttp.ClientResponse,
+        url: str,
+        **kwargs: Union[int, Optional[str]]
+    ) -> Dict:
+        json_response: Dict = {}
+        try:
+            json_response = await response.json()
+        except json.decoder.JSONDecodeError:
+            pass
+        self._check_response(response_dict=json_response, response_status_code=response.status, **kwargs)
+        return self._add_jikan_metadata(response, json_response, url)
 
     async def _get(  # type: ignore
         self,
@@ -46,19 +45,15 @@ class AioJikan(AbstractJikan):
         page: Optional[int] = None,
     ) -> Dict:
         url: str = self._get_url(endpoint, id, extension, page)
-        response = await self.session.get(url)
-        await self._check_response(response, id=id, endpoint=endpoint)
-        json = await response.json()
-        return json
+        response: aiohttp.ClientResponse = await self.session.get(url)
+        return await self._wrap_response(response, url, id=id, endpoint=endpoint)
 
     async def _get_creator(  # type: ignore
         self, creator_type: str, creator_id: int, page: Optional[int] = None
     ) -> Dict:
         url: str = self._get_creator_url(creator_type, creator_id, page)
-        response = await self.session.get(url)
-        await self._check_response(response, id=creator_id, endpoint=creator_type)
-        json = await response.json()
-        return json
+        response: aiohttp.ClientResponse = await self.session.get(url)
+        return await self._wrap_response(response, url, id=creator_id, endpoint=creator_type)
 
     async def search(  # type: ignore
         self,
@@ -68,55 +63,41 @@ class AioJikan(AbstractJikan):
         parameters: Optional[Mapping[str, Optional[Union[int, str, float]]]] = None,
     ) -> Dict:
         url: str = self._get_search_url(search_type, query, page, parameters)
-        response = await self.session.get(url)
+        response: aiohttp.ClientResponse = await self.session.get(url)
         kwargs: Dict[str, str] = {"search type": search_type, "query": query}
-        await self._check_response(response, **kwargs)
-        json = await response.json()
-        return json
+        return await self._wrap_response(response, url, **kwargs)
 
     async def season(self, year: int, season: str) -> Dict:  # type: ignore
         url: str = self._get_season_url(year, season)
-        response = await self.session.get(url)
-        await self._check_response(response, year=year, season=season)
-        json = await response.json()
-        return json
+        response: aiohttp.ClientResponse = await self.session.get(url)
+        return await self._wrap_response(response, url, year=year, season=season)
 
     async def season_archive(self) -> Dict:  # type: ignore
-        response = await self.session.get(self.season_archive_url)
-        await self._check_response(response)
-        json = await response.json()
-        return json
+        response: aiohttp.ClientResponse = await self.session.get(self.season_archive_url)
+        return await self._wrap_response(response, self.season_archive_url)
 
     async def season_later(self) -> Dict:  # type: ignore
-        response = await self.session.get(self.season_later_url)
-        await self._check_response(response)
-        json = await response.json()
-        return json
+        response: aiohttp.ClientResponse = await self.session.get(self.season_later_url)
+        return await self._wrap_response(response, self.season_later_url)
 
     async def schedule(self, day: Optional[str] = None) -> Dict:  # type: ignore
         url: str = self._get_schedule_url(day)
-        response = await self.session.get(url)
-        await self._check_response(response, day=day)
-        json = await response.json()
-        return json
+        response: aiohttp.ClientResponse = await self.session.get(url)
+        return await self._wrap_response(response, url, day=day)
 
     async def top(  # type: ignore
         self, type: str, page: Optional[int] = None, subtype: Optional[str] = None
     ) -> Dict:
         url: str = self._get_top_url(type, page, subtype)
-        response = await self.session.get(url)
-        await self._check_response(response, type=type)
-        json = await response.json()
-        return json
+        response: aiohttp.ClientResponse = await self.session.get(url)
+        return await self._wrap_response(response, url, type=type)
 
     async def genre(  # type: ignore
         self, type: str, genre_id: int, page: Optional[int] = None
     ) -> Dict:
         url: str = self._get_genre_url(type, genre_id, page)
-        response = await self.session.get(url)
-        await self._check_response(response, id=genre_id, type=type)
-        json = await response.json()
-        return json
+        response: aiohttp.ClientResponse = await self.session.get(url)
+        return await self._wrap_response(response, url, id=genre_id, type=type)
 
     async def user(  # type: ignore
         self,
@@ -127,10 +108,8 @@ class AioJikan(AbstractJikan):
         parameters: Optional[Mapping] = None,
     ) -> Dict:
         url: str = self._get_user_url(username, request, argument, page, parameters)
-        response = await self.session.get(url)
-        await self._check_response(response, username=username, request=request)
-        json = await response.json()
-        return json
+        response: aiohttp.ClientResponse = await self.session.get(url)
+        return await self._wrap_response(response, url, username=username, request=request)
 
     async def meta(  # type: ignore
         self,
@@ -140,10 +119,8 @@ class AioJikan(AbstractJikan):
         offset: Optional[int] = None,
     ) -> Dict:
         url: str = self._get_meta_url(request, type, period, offset)
-        response = await self.session.get(url)
-        await self._check_response(response, request=request, type=type, period=period)
-        json = await response.json()
-        return json
+        response: aiohttp.ClientResponse = await self.session.get(url)
+        return await self._wrap_response(response, url, request=request, type=type, period=period)
 
     async def close(self) -> None:
         await self.session.close()

--- a/jikanpy/aiojikan.py
+++ b/jikanpy/aiojikan.py
@@ -23,18 +23,20 @@ class AioJikan(AbstractJikan):
             aiohttp.ClientSession(loop=self.loop) if session is None else session
         )
 
-    async def _wrap_response( # type: ignore
+    async def _wrap_response(  # type: ignore
         self,
         response: aiohttp.ClientResponse,
         url: str,
-        **kwargs: Union[int, Optional[str]]
+        **kwargs: Union[int, Optional[str]],
     ) -> Dict:
         json_response: Dict = {}
         try:
             json_response = await response.json()
         except json.decoder.JSONDecodeError:
             pass
-        self._check_response(response_dict=json_response, response_status_code=response.status, **kwargs)
+        self._check_response(
+            response_dict=json_response, response_status_code=response.status, **kwargs
+        )
         return self._add_jikan_metadata(response, json_response, url)
 
     async def _get(  # type: ignore
@@ -53,7 +55,9 @@ class AioJikan(AbstractJikan):
     ) -> Dict:
         url: str = self._get_creator_url(creator_type, creator_id, page)
         response: aiohttp.ClientResponse = await self.session.get(url)
-        return await self._wrap_response(response, url, id=creator_id, endpoint=creator_type)
+        return await self._wrap_response(
+            response, url, id=creator_id, endpoint=creator_type
+        )
 
     async def search(  # type: ignore
         self,
@@ -73,7 +77,9 @@ class AioJikan(AbstractJikan):
         return await self._wrap_response(response, url, year=year, season=season)
 
     async def season_archive(self) -> Dict:  # type: ignore
-        response: aiohttp.ClientResponse = await self.session.get(self.season_archive_url)
+        response: aiohttp.ClientResponse = await self.session.get(
+            self.season_archive_url
+        )
         return await self._wrap_response(response, self.season_archive_url)
 
     async def season_later(self) -> Dict:  # type: ignore
@@ -109,7 +115,9 @@ class AioJikan(AbstractJikan):
     ) -> Dict:
         url: str = self._get_user_url(username, request, argument, page, parameters)
         response: aiohttp.ClientResponse = await self.session.get(url)
-        return await self._wrap_response(response, url, username=username, request=request)
+        return await self._wrap_response(
+            response, url, username=username, request=request
+        )
 
     async def meta(  # type: ignore
         self,
@@ -120,7 +128,9 @@ class AioJikan(AbstractJikan):
     ) -> Dict:
         url: str = self._get_meta_url(request, type, period, offset)
         response: aiohttp.ClientResponse = await self.session.get(url)
-        return await self._wrap_response(response, url, request=request, type=type, period=period)
+        return await self._wrap_response(
+            response, url, request=request, type=type, period=period
+        )
 
     async def close(self) -> None:
         await self.session.close()

--- a/jikanpy/jikan.py
+++ b/jikanpy/jikan.py
@@ -1,4 +1,7 @@
+import json
 from typing import Optional, Dict, Any, Mapping, Union
+
+import requests
 
 from jikanpy.abstractjikan import AbstractJikan
 from jikanpy import session
@@ -6,6 +9,23 @@ from jikanpy import session
 
 class Jikan(AbstractJikan):
     """Synchronous Jikan wrapper"""
+
+    def _wrap_response(
+        self,
+        response: requests.Response,
+        url: str,
+        **kwargs: Union[int, Optional[str]]
+    ) -> Dict:
+        json_response: Dict = {}
+        try:
+            json_response = response.json()
+        except json.decoder.JSONDecodeError:
+            # json failed to be parsed
+            # this could happen, for example, when someone has been IP banned
+            # and it returns the typical nginx 403 forbidden page
+            pass
+        self._check_response(response_dict=json_response, response_status_code=response.status_code, **kwargs)
+        return self._add_jikan_metadata(response, json_response, url)
 
     def _get(
         self,
@@ -15,17 +35,15 @@ class Jikan(AbstractJikan):
         page: Optional[int] = None,
     ) -> Dict:
         url: str = self._get_url(endpoint, id, extension, page)
-        response: Any = session.get(url)
-        self._check_response(response, id=id, endpoint=endpoint)
-        return response.json()
+        response: requests.Response = session.get(url)
+        return self._wrap_response(response, url, id=id, endpoint=endpoint)
 
     def _get_creator(
         self, creator_type: str, creator_id: int, page: Optional[int] = None
     ) -> Dict:
         url: str = self._get_creator_url(creator_type, creator_id, page)
-        response: Any = session.get(url)
-        self._check_response(response, id=creator_id, endpoint=creator_type)
-        return response.json()
+        response: requests.Response = session.get(url)
+        return self._wrap_response(response, url, id=creator_id, endpoint=creator_type)
 
     def search(
         self,
@@ -35,46 +53,39 @@ class Jikan(AbstractJikan):
         parameters: Optional[Mapping[str, Optional[Union[int, str, float]]]] = None,
     ) -> Dict:
         url: str = self._get_search_url(search_type, query, page, parameters)
-        response: Any = session.get(url)
+        response: requests.Response = session.get(url)
         kwargs: Dict[str, str] = {"search type": search_type, "query": query}
-        self._check_response(response, **kwargs)
-        return response.json()
+        return self._wrap_response(response, url, **kwargs)
 
     def season(self, year: int, season: str) -> Dict:
         url: str = self._get_season_url(year, season)
-        response: Any = session.get(url)
-        self._check_response(response, year=year, season=season)
-        return response.json()
+        response: requests.Response = session.get(url)
+        return self._wrap_response(response, url, year=year, season=season)
 
     def season_archive(self) -> Dict:
-        response: Any = session.get(self.season_archive_url)
-        self._check_response(response)
-        return response.json()
+        response: requests.Response = session.get(self.season_archive_url)
+        return self._wrap_response(response, self.season_archive_url)
 
     def season_later(self) -> Dict:
-        response: Any = session.get(self.season_later_url)
-        self._check_response(response)
-        return response.json()
+        response: requests.Response = session.get(self.season_later_url)
+        return self._wrap_response(response, self.season_later_url)
 
     def schedule(self, day: Optional[str] = None) -> Dict:
         url: str = self._get_schedule_url(day)
-        response: Any = session.get(url)
-        self._check_response(response, day=day)
-        return response.json()
+        response: requests.Response = session.get(url)
+        return self._wrap_response(response, url, day=day)
 
     def top(
         self, type: str, page: Optional[int] = None, subtype: Optional[str] = None
     ) -> Dict:
         url: str = self._get_top_url(type, page, subtype)
-        response: Any = session.get(url)
-        self._check_response(response, type=type)
-        return response.json()
+        response: requests.Response = session.get(url)
+        return self._wrap_response(response, url, type=type)
 
     def genre(self, type: str, genre_id: int, page: Optional[int] = None) -> Dict:
         url: str = self._get_genre_url(type, genre_id, page)
-        response: Any = session.get(url)
-        self._check_response(response, id=genre_id, type=type)
-        return response.json()
+        response: requests.Response = session.get(url)
+        return self._wrap_response(response, url, id=genre_id, type=type)
 
     def user(
         self,
@@ -85,9 +96,8 @@ class Jikan(AbstractJikan):
         parameters: Optional[Mapping] = None,
     ) -> Dict:
         url: str = self._get_user_url(username, request, argument, page, parameters)
-        response: Any = session.get(url)
-        self._check_response(response, username=username, request=request)
-        return response.json()
+        response: requests.Response = session.get(url)
+        return self._wrap_response(response, url, username=username, request=request)
 
     def meta(
         self,
@@ -97,6 +107,5 @@ class Jikan(AbstractJikan):
         offset: Optional[int] = None,
     ) -> Dict:
         url: str = self._get_meta_url(request, type, period, offset)
-        response: Any = session.get(url)
-        self._check_response(response, request=request, type=type, period=period)
-        return response.json()
+        response: requests.Response = session.get(url)
+        return self._wrap_response(response, url, request=request, type=type, period=period)

--- a/jikanpy/jikan.py
+++ b/jikanpy/jikan.py
@@ -11,10 +11,7 @@ class Jikan(AbstractJikan):
     """Synchronous Jikan wrapper"""
 
     def _wrap_response(
-        self,
-        response: requests.Response,
-        url: str,
-        **kwargs: Union[int, Optional[str]]
+        self, response: requests.Response, url: str, **kwargs: Union[int, Optional[str]]
     ) -> Dict:
         json_response: Dict = {}
         try:
@@ -24,7 +21,11 @@ class Jikan(AbstractJikan):
             # this could happen, for example, when someone has been IP banned
             # and it returns the typical nginx 403 forbidden page
             pass
-        self._check_response(response_dict=json_response, response_status_code=response.status_code, **kwargs)
+        self._check_response(
+            response_dict=json_response,
+            response_status_code=response.status_code,
+            **kwargs,
+        )
         return self._add_jikan_metadata(response, json_response, url)
 
     def _get(
@@ -108,4 +109,6 @@ class Jikan(AbstractJikan):
     ) -> Dict:
         url: str = self._get_meta_url(request, type, period, offset)
         response: requests.Response = session.get(url)
-        return self._wrap_response(response, url, request=request, type=type, period=period)
+        return self._wrap_response(
+            response, url, request=request, type=type, period=period
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,15 @@ def response_mock():
         def __init__(self):
             self.status = 403
             self.status_code = 403
+            # simulate a banned user
+            self.text = """<html>
+<head><title>403 Forbidden</title></head>
+<body>
+<center><h1>403 Forbidden</h1></center>
+<hr><center>nginx/1.15.5 (Ubuntu)</center>
+</body>
+</html>
+"""
 
         def json(self):
             raise json.decoder.JSONDecodeError("Failed", "", 0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -362,3 +362,14 @@ def club_keys():
         "manga_relations",
         "character_relations",
     }
+
+
+@pytest.fixture
+def header_keys():
+    return {
+        "X-Cache-Status",
+        "X-Request-Hash",
+        "X-Request-Cached",
+        "X-Request-Cache-Ttl",
+        "ETag",
+    }

--- a/tests/test_abstractjikan.py
+++ b/tests/test_abstractjikan.py
@@ -14,6 +14,9 @@ def test_get_creator_url_type_failure(abstract_jikan):
     with pytest.raises(ClientException):
         abstract_jikan._get_creator_url("x", 1, 1)
 
+def test_wrap_response_not_implemented(abstract_jikan):
+    with pytest.raises(NotImplementedError):
+        abstract_jikan._wrap_response(None, None)
 
 def test_get_not_implemented(abstract_jikan):
     with pytest.raises(NotImplementedError):

--- a/tests/test_abstractjikan.py
+++ b/tests/test_abstractjikan.py
@@ -14,9 +14,11 @@ def test_get_creator_url_type_failure(abstract_jikan):
     with pytest.raises(ClientException):
         abstract_jikan._get_creator_url("x", 1, 1)
 
+
 def test_wrap_response_not_implemented(abstract_jikan):
     with pytest.raises(NotImplementedError):
         abstract_jikan._wrap_response(None, None)
+
 
 def test_get_not_implemented(abstract_jikan):
     with pytest.raises(NotImplementedError):

--- a/tests/test_aiojikan.py
+++ b/tests/test_aiojikan.py
@@ -29,6 +29,19 @@ def aio_jikan(event_loop):
     return AioJikan(loop=event_loop)
 
 
+@vcr.use_cassette("tests/vcr_cassettes/aio-wrap-response.yaml")
+async def test_wrap_response(aio_jikan):
+    anime_info = await aio_jikan.anime(MUSHISHI_ID)
+    mushishi_url = aio_jikan._get_url("anime", MUSHISHI_ID, extension=None, page=None)
+
+    assert isinstance(anime_info, dict)
+    assert "jikan_url" in anime_info
+    assert "headers" in anime_info
+    assert isinstance(anime_info["headers"], dict)
+    assert mushishi_url == anime_info["jikan_url"]
+    await aio_jikan.close()
+
+
 @vcr.use_cassette("tests/vcr_cassettes/aio-anime-success.yaml")
 async def test_anime_success(anime_keys, aio_jikan):
     anime_info = await aio_jikan.anime(MUSHISHI_ID)

--- a/tests/test_aiojikan.py
+++ b/tests/test_aiojikan.py
@@ -503,5 +503,5 @@ async def test_user_list_failure(aio_jikan):
 
 async def test_empty_response_json(aio_jikan, response_mock):
     with pytest.raises(APIException):
-        await aio_jikan._check_response(response_mock)
+        await aio_jikan._wrap_response(response_mock, url="")
     await aio_jikan.close()

--- a/tests/test_jikan.py
+++ b/tests/test_jikan.py
@@ -27,6 +27,30 @@ def jikan():
     return Jikan()
 
 
+@vcr.use_cassette("tests/vcr_cassettes/wrap-response.yaml")
+def test_wrap_response(jikan):
+    anime_info = jikan.anime(MUSHISHI_ID)
+    mushishi_url = jikan._get_url("anime", MUSHISHI_ID, extension=None, page=None)
+
+    assert isinstance(anime_info, dict)
+    assert "jikan_url" in anime_info
+    assert "headers" in anime_info
+    assert isinstance(anime_info["headers"], dict)
+    assert mushishi_url == anime_info["jikan_url"]
+
+
+# Test against headers mentioned in documentation
+# https://jikan.docs.apiary.io/#introduction/information/caching
+@vcr.use_cassette("tests/vcr_cassettes/wrap-response.yaml")
+def test_header_contents(header_keys, jikan):
+    anime_info = jikan.anime(MUSHISHI_ID)
+
+    assert isinstance(anime_info, dict)
+    assert "headers" in anime_info
+    assert isinstance(anime_info["headers"], dict)
+    assert header_keys.issubset(anime_info["headers"].keys())
+
+
 @vcr.use_cassette("tests/vcr_cassettes/anime-success.yaml")
 def test_anime_success(anime_keys, jikan):
     anime_info = jikan.anime(MUSHISHI_ID)

--- a/tests/test_jikan.py
+++ b/tests/test_jikan.py
@@ -28,7 +28,7 @@ def jikan():
 
 
 @vcr.use_cassette("tests/vcr_cassettes/wrap-response.yaml")
-def test_wrap_response(jikan):
+def test_wrap_response(header_keys, jikan):
     anime_info = jikan.anime(MUSHISHI_ID)
     mushishi_url = jikan._get_url("anime", MUSHISHI_ID, extension=None, page=None)
 
@@ -37,17 +37,8 @@ def test_wrap_response(jikan):
     assert "headers" in anime_info
     assert isinstance(anime_info["headers"], dict)
     assert mushishi_url == anime_info["jikan_url"]
-
-
-# Test against headers mentioned in documentation
-# https://jikan.docs.apiary.io/#introduction/information/caching
-@vcr.use_cassette("tests/vcr_cassettes/wrap-response.yaml")
-def test_header_contents(header_keys, jikan):
-    anime_info = jikan.anime(MUSHISHI_ID)
-
-    assert isinstance(anime_info, dict)
-    assert "headers" in anime_info
-    assert isinstance(anime_info["headers"], dict)
+    # Test against headers mentioned in documentation
+    # https://jikan.docs.apiary.io/#introduction/information/caching
     assert header_keys.issubset(anime_info["headers"].keys())
 
 

--- a/tests/test_jikan.py
+++ b/tests/test_jikan.py
@@ -438,4 +438,4 @@ def test_user_list_failure(jikan):
 
 def test_empty_response_json(jikan, response_mock):
     with pytest.raises(APIException):
-        jikan._check_response(response_mock)
+        jikan._wrap_response(response_mock, url="")

--- a/tests/vcr_cassettes/aio-wrap-response.yaml
+++ b/tests/vcr_cassettes/aio-wrap-response.yaml
@@ -1,0 +1,85 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.jikan.moe/v3/anime/457
+  response:
+    body:
+      string: '{"request_hash":"request:anime:047ce4420fa843606934309866d292274c149a83","request_cached":true,"request_cache_expiry":55606,"mal_id":457,"url":"https:\/\/myanimelist.net\/anime\/457\/Mushishi","image_url":"https:\/\/cdn.myanimelist.net\/images\/anime\/2\/73862.jpg","trailer_url":"https:\/\/www.youtube.com\/embed\/h371H0KIuPo?enablejsapi=1&wmode=opaque&autoplay=1","title":"Mushishi","title_english":"Mushi-Shi","title_japanese":"\u87f2\u5e2b","title_synonyms":[],"type":"TV","source":"Manga","episodes":26,"status":"Finished
+        Airing","airing":false,"aired":{"from":"2005-10-23T00:00:00+00:00","to":"2006-06-19T00:00:00+00:00","prop":{"from":{"day":23,"month":10,"year":2005},"to":{"day":19,"month":6,"year":2006}},"string":"Oct
+        23, 2005 to Jun 19, 2006"},"duration":"25 min per ep","rating":"PG-13 - Teens
+        13 or older","score":8.72,"scored_by":167461,"rank":40,"popularity":130,"members":481559,"favorites":20002,"synopsis":"\"Mushi\":
+        the most basic forms of life in the world. They exist without any goals or
+        purposes aside from simply \"being.\" They are beyond the shackles of the
+        words \"good\" and \"evil.\" Mushi can exist in countless forms and are capable
+        of mimicking things from the natural world such as plants, diseases, and even
+        phenomena like rainbows. This is, however, just a vague definition of these
+        entities that inhabit the vibrant world of Mushishi, as to even call them
+        a form of life would be an oversimplification. Detailed information on Mushi
+        is scarce because the majority of humans are unaware of their existence. So
+        what are Mushi and why do they exist? This is the question that a \"Mushishi,\"
+        Ginko, ponders constantly. Mushishi are those who research Mushi in hopes
+        of understanding their place in the world''s hierarchy of life. Ginko chases
+        rumors of occurrences that could be tied to Mushi, all for the sake of finding
+        an answer. It could, after all, lead to the meaning of life itself. [Written
+        by MAL Rewrite]","background":"Mushishi is an adaptation of Yuki Urushibara''s
+        award-winning manga of the same name. The series adapts the first 26 chapters
+        of the manga, adapting one per episode. The anime aired these stories in a
+        different order than that of the manga.\r\nThe series won the Tokyo Anime
+        Award in the Television category in 2006. The series premiered on October
+        23, 2005, but went on hiatus on March 12, 2006 after having aired 20 episodes.
+        Broadcast resumed on May 15, and aired the remaining 6 episodes, concluding
+        on June 19, 2006.","premiered":"Fall 2005","broadcast":"Sundays at 03:40 (JST)","related":{"Adaptation":[{"mal_id":418,"type":"manga","name":"Mushishi","url":"https:\/\/myanimelist.net\/manga\/418\/Mushishi"}],"Sequel":[{"mal_id":21329,"type":"anime","name":"Mushishi:
+        Hihamukage","url":"https:\/\/myanimelist.net\/anime\/21329\/Mushishi__Hihamukage"},{"mal_id":21939,"type":"anime","name":"Mushishi
+        Zoku Shou","url":"https:\/\/myanimelist.net\/anime\/21939\/Mushishi_Zoku_Shou"}],"Summary":[{"mal_id":39738,"type":"anime","name":"Mushishi
+        Recap","url":"https:\/\/myanimelist.net\/anime\/39738\/Mushishi_Recap"}]},"producers":[{"mal_id":52,"type":"anime","name":"Avex
+        Entertainment","url":"https:\/\/myanimelist.net\/anime\/producer\/52\/Avex_Entertainment"},{"mal_id":82,"type":"anime","name":"Marvelous","url":"https:\/\/myanimelist.net\/anime\/producer\/82\/Marvelous"},{"mal_id":147,"type":"anime","name":"SKY
+        Perfect Well Think","url":"https:\/\/myanimelist.net\/anime\/producer\/147\/SKY_Perfect_Well_Think"},{"mal_id":711,"type":"anime","name":"Delfi
+        Sound","url":"https:\/\/myanimelist.net\/anime\/producer\/711\/Delfi_Sound"}],"licensors":[{"mal_id":102,"type":"anime","name":"Funimation","url":"https:\/\/myanimelist.net\/anime\/producer\/102\/Funimation"}],"studios":[{"mal_id":8,"type":"anime","name":"Artland","url":"https:\/\/myanimelist.net\/anime\/producer\/8\/Artland"}],"genres":[{"mal_id":2,"type":"anime","name":"Adventure","url":"https:\/\/myanimelist.net\/anime\/genre\/2\/Adventure"},{"mal_id":36,"type":"anime","name":"Slice
+        of Life","url":"https:\/\/myanimelist.net\/anime\/genre\/36\/Slice_of_Life"},{"mal_id":7,"type":"anime","name":"Mystery","url":"https:\/\/myanimelist.net\/anime\/genre\/7\/Mystery"},{"mal_id":13,"type":"anime","name":"Historical","url":"https:\/\/myanimelist.net\/anime\/genre\/13\/Historical"},{"mal_id":37,"type":"anime","name":"Supernatural","url":"https:\/\/myanimelist.net\/anime\/genre\/37\/Supernatural"},{"mal_id":10,"type":"anime","name":"Fantasy","url":"https:\/\/myanimelist.net\/anime\/genre\/10\/Fantasy"},{"mal_id":42,"type":"anime","name":"Seinen","url":"https:\/\/myanimelist.net\/anime\/genre\/42\/Seinen"}],"opening_themes":["\"The
+        Sore Feet Song\" by Ally Kerr"],"ending_themes":["\"Midori no Za\" (\u7dd1\u306e\u5ea7)
+        by Masuda Toshio (ep 1)","\"Mabuta no Hikari\" (\u77bc\u306e\u5149) by Masuda
+        Toshio (ep 2)","\"Yawarakai Kaku\" (\u67d4\u3089\u304b\u3044\u89d2) by Masuda
+        Toshio (ep 3)","\"Makura Kouji\" (\u6795\u5c0f\u8def ) by Masuda Toshio (ep
+        4)","\"Tabi wo Suru Numa\" (\u65c5\u3092\u3059\u308b\u6cbc) by Masuda Toshio
+        (ep 5)","\"Tsuyu wo Suu Mure\" (\u9732\u3092\u5438\u3046\u7fa4\u308c) by Masuda
+        Toshio (ep 6)","\"Ame ga Kuru Niji ga Tatsu\" (\u96e8\u304c\u304f\u308b\u8679\u304c\u305f\u3064)
+        by Masuda Toshio (ep 7)","\"Unasaka Yori\" (\u6d77\u5883\u3088\u308a)  by
+        Masuda Toshio (ep 8)","\"Omoi Mi\" (\u91cd\u3044\u5b9f) by Masuda Toshio (ep
+        9)","\"Suzuri ni Sumu Shiro\" (\u786f\u306b\u68f2\u3080\u767d) by Masuda Toshio
+        (ep 10)","\"Yama Nemuru\" (\u3084\u307e\u306d\u3080\u308b) by Masuda Toshio
+        (ep 11)","\"Sugame no Sakana\" (\u7707\u306e\u9b5a) by Masuda Toshio (ep 12)","\"Hitoyobashi\"
+        (\u4e00\u591c\u6a4b) by Masuda Toshio (ep 13)","\"Kago no Naka\" (\u7c60\u306e\u306a\u304b)
+        by Masuda Toshio (ep 14)","\"Haru to Usobuko\" (\u6625\u3068\u562f\u304f)
+        by Masuda Toshio (ep 15)","\"Akatsuki no Hebi\" (\u6681\u306e\u86c7) by Masuda
+        Toshio (ep 16)","\"Uromayutori\" (\u865a\u7e6d\u53d6\u308a) by Masuda Toshio
+        (ep 17)","\"Yama Daku Koromo\" (\u5c71\u62b1\u304f\u8863) by Masuda Toshio
+        (ep 18)","\"Tenpen no Ito\" (\u5929\u8fba\u306e\u7cf8) by Masuda Toshio (ep
+        19)","\"Fude no Umi\" (\u7b46\u306e\u6d77) by Masuda Toshio (ep 20)","\"Wataboshi\"
+        (\u7dbf\u80de\u5b50) by Masuda Toshio (ep 21)","\"Okitsu Miya\" (\u6c96\u3064\u5bae)
+        by Masuda Toshio (ep 22)","\"Sabi no Naku Koe\" (\u9306\u306e\u9cf4\u304f\u8072)
+        by Masuda Toshio (ep 23)","\"Kagarinokou\" (\u7bdd\u91ce\u884c) by Masuda
+        Toshio (ep 24)","\"Ganpuku Ganka\" (\u773c\u798f\u773c\u798d) by Masuda Toshio
+        (ep 25)","\"Kusa wo Fumu Oto\" (\u8349\u3092\u8e0f\u3080\u97f3) by Masuda
+        Toshio (ep 26)"]}'
+    headers:
+      Access-Control-Allow-Methods: '*'
+      Access-Control-Allow-Origin: '*'
+      Connection: keep-alive
+      Content-Encoding: gzip
+      Content-Length: '2609'
+      Content-Type: application/json
+      Date: Sat, 31 Aug 2019 21:19:25 GMT
+      Etag: '"95f4ab8888d32d317d0f0e080bb4ae1a"'
+      Server: nginx/1.14.0 (Ubuntu)
+      Vary: Accept-Encoding
+      X-Cache-Status: MISS
+      X-Request-Cache-Ttl: '55606'
+      X-Request-Cached: '1'
+      X-Request-Hash: request:anime:047ce4420fa843606934309866d292274c149a83
+    status:
+      code: 200
+      message: OK
+    url: https://api.jikan.moe/v3/anime/457
+version: 1

--- a/tests/vcr_cassettes/wrap-response.yaml
+++ b/tests/vcr_cassettes/wrap-response.yaml
@@ -1,0 +1,96 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://api.jikan.moe/v3/anime/457
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA51Y/W/bOBL9Vwj/sNfiHEffkgMUixx63XSz/cAmvaK7LgxKomzGkqiVxLi6Iv/7
+        vaEkx2lX6CVA4NoS583jzJvhsF9ntfhLi6Zdb3mznZ2NP894KQtxZnlhIjzPsTIeeW5gBUvXc61l
+        FASps3Sc0Etsb8kjdzY/4CQ82Yp0dtbWWnzzdC2+VLLuZme+D6j5rOD5WmKp54fzma5zuN+2bdWc
+        rU5Xp0VnKOSyaRelaFen5ufqFItXp290s5X4g19Z8I1Yf2udpOXiOwSztDkgOavT0I0CZ3FTbQDU
+        1lzmov4Oar/fLzqlWx2LRaKK1akoYpGuTrduaF9Yl6/1e/WzKHmci5uGV/KF/dO+UKl4oSqOvf/E
+        dauqnHcvbPIh21wA/Yi/ebQW5QY8t+Ork6ujdze84qVoyG6lozBzVtoXTnx433SlKruimZ39+RnP
+        uopWXv8H7xul68T44+WG44GoZANuWOog/k3LW43vs1eyhHORsnNZy5KCwfsvZxnPG2F+Uk6/zrJa
+        FTBwLMs/sa0Tx722rDPz90/zSaRUvyA4wZ+9/H5BVavqHuvrLOWQhONCD6psEQLbms86wWs8hJu7
+        HnFYZi8Py4KjVcHdHW2n5zx7l7QMeIzMWavYr7pkMKTfwQwLU13zVqqSePqskCWrRM1ERSrGC4Px
+        /pcT22Un7FqIsmH4qmqm8lTUFNZE1YhqtAid4Ue6jolcEHqBTSDlDqrGNipV6ZzXsqW3Lh4UJJ4a
+        Mfci2/exmYzfKrw3KbEsiwCRzqqRlJdVr4bV7Iy1W8EK1bQs5o1MWKbqomEqY7nMBMMO6P1e1Xm6
+        YNdb0THxBbJne9luIV3Gy45tFHJJ26h0XalGNAxIqWCUBtbIoso7tprFAvtfrGY9Cq8Fi0WnytQ4
+        aLY82eXCOB4cpg2MNkqlMOFYtpqJW5kTgKHOEl4OXEAyUbqEYptm4E8G5CKBwlE/BFvIQiY7cIAD
+        fDY9PXJWQqw1z/tdskYnW2yAobTKtpmzVDaCY1NzAypuBZK6FaUqUJoI0k4wlHcZq31DAZINk1i6
+        VXusrOfsRoMgZ7d8owVLRYZ6IIEM+2wEEyVqTWLn7ZbTVrY8lq2hdStj5LsdaMFgrO050YP6DJeE
+        5zktL+CF9n5I3V5pmMUCtJkCF5MImcnEKHTBXoqW2lIKn2THe1rlEF3so0k4ahwICdcganTCb0hT
+        HTnZ6oJDwBRlXfI9/dtvStZ9XkSZiAW7UmxPO6P3PTSFcb/tWKpo9SCon8fYGT+mtRMfExTOVoe+
+        Nkf+f5HlTs1ZBfFgW8h9iX6D9HeLQ4iMOygUvPdbxWpEGpvZjpsrkaCqV5s2ILBPe2kQfaQ+eaj9
+        fzRsK0VNGN0Y4UVPhCVbkgerdaFqA6mSRNc1bX/IajKmAolOKXOGBtKI1CH2fQXwnQkgFGKYIGsI
+        717UC/Z6QIBB1qKfwGzOcsENlEmLwMEDm0PVto3IswX78yOShTywuGNvzn9jv4s9dYTP6DQx6m1T
+        o2rSo0ODwk9+U161fJTpJ72T7ENNS2Jec0SCkp2e7GVpnBZ0Aox12/CC6qkQplmwRtQkbQPYZzaT
+        CDZzAopa1Yr6UPEGZt4vNXspxdA8zcHS45nzlZkzYyifplXGBZLFUapZJhD4Fs0IWaXgDxI6drJY
+        1avyiN1e9Ym+VrtOsXPj4py2OCrgWuRoPQ3FA8UjNqru6BU1/QfbrGpRQCTghpU4KhQa8uG4mLMY
+        7XJvyEF+kg5IU25Gl7bTHyJDhrf81mjAbNSxxiCgw/yrVjxNOGIITeui9/WGd8z2+wZ1CA4WFGhM
+        hBMcAOZULUmu0z7EdICJwwm2MEfosAc6vEmfxJ30MvrF8yuohndIa8ssF6cRe/br1fVzM6nliI85
+        zs8PGsLw8PV+ILOjwyBRDKMDyeXh5PLDic2YYmKzo6OJ7Q4zyhVNhfkDl47tOsuDUwP0vdMzdiG3
+        vNA7zHH/D4Fx0CPsewrr9RHK3fyYw9L9IQf2h9ppdoVj9VEMgHzEgDDWBsOEQxcFp7n4KB7uErPp
+        D7n8jq5fPYKHQT3i0dvffb4zU1mqEzObHNHwnSkO57fiC/t3iTrAAVXimG0fwWN0tjr1MYUT1Poh
+        1HFaokkOqMpbkSvMsE9xHcH1PcKxR9sLp1xeXX5i70WdCcyYHwUqDwcipr2n+IeX1Snw1gPemvDW
+        Pd4xm9C2p9i8xAEicXjTAfEUCoBenRqQdQ9CcsxlgplXfaME25pMwyuN330XeVIcLCTiCIM4NC2a
+        n3rIYLIczusWU+DTIoBqGM3J70aUtXjodroCUkx2mEkf04oMvrl63lsf59oNJoVHaaET8jfMDo/3
+        6AbQGkGsVbY2EA8kNllhHSZEtKZH+6NL+mD7oLLcKU8X0gwJGJQf78x2V6dH9g8COl3JGoPLcKl4
+        Qjypdo8RHuzSmiwVTMC8eUI8bQs1Mhgfu/Im5XmFm5x4TEUOnjyIc7ClisAETtPJmi4vpjJwK6Vp
+        6grXXvZKiBbfyg3mfUyv5znukJeirmcwFGZCfmD3RqZIESsV+4PD4tlKh2lqr7RrBYL+U4OHz80Q
+        zBudckx6OKIUeyYqZtPcAnuO6YyT/YXc4Vo9YIRxcsCwveUEhtNjfKK5mO+4ZJd8p3uEIEw9QoiW
+        9OnF5hNPomXqTKC5I6Mdss8ulb6RI9bSB4/EymCPqySbAPB6gGtcJDHbsitda/YWl7UBxU98YrF0
+        6NM3vCLwCpI4mQD0B8BGd7pH1LjBIKMGEAe/MwL6HoYA2mKA4GW83/oUbNDDnmPcxgXi0tCUN5J+
+        XPO2GSK4DEQPaTLhZSPfCOG4f+6b54E34SrsXX0oOa5ZnH1SY4aDNAxBO4pcg2s8Rfw5+3uYqId5
+        VyjJ3gwISztJx6z68TKbYLDsTa/0fzXpFEerLmjYk7UatBYF/R4oF1FmQhpZeA4JTWnXGoVXcPZW
+        FIhgjwVLE/pQGMR0xKLITWHZI8GNucIhy4hUORZTaIVjISxjn0+BDJVwIVvVqZib/2Eie09YcO8j
+        Vtgc9yZJDNq/5BtFFN6CwkAgCayRAD55X01TMEMFXHBIClfkD42K9W6IcxA4Rv8Bcu0HTtaragpp
+        kP75jgS5Mw3mQsSjeILo0GKiIJlsMYPQP9Sq4J1uD+KLAh8bCQUlyHfTYBTf36OER8l+ieaA1gDA
+        YVd+EoJK4MT2WCVRFLhTUIOOr0WJFkx7et2OOEvcZ3SUxXzcWJhk0RTOIOpXOjWK+VCMfTP2gtGe
+        Kmyqbw76/chbHquDWMI0Jv5WSl039q0p60Gx73YSuUE9dmOHS5a9d1ORXEzZD2K9oj7Zi41iOnY1
+        2B8Un2TeIaxWONW4nXv14gQp1U7pMRxpahoF6STypvqhM8j2F15WGlzw70H+oYvKCZdRdvR9qi04
+        g2gvdcOpXb+iTvNuzHDkesuxXUfCysbesAyzKb04EPDnu/8BlJJ/SdEZAAA=
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2609'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 31 Aug 2019 21:19:26 GMT
+      ETag:
+      - '"95f4ab8888d32d317d0f0e080bb4ae1a"'
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Vary:
+      - Accept-Encoding
+      X-Cache-Status:
+      - HIT
+      X-Request-Cache-Ttl:
+      - '55606'
+      X-Request-Cached:
+      - '1'
+      X-Request-Hash:
+      - request:anime:047ce4420fa843606934309866d292274c149a83
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
#54 

This adds the jikan_url and response headers to requests:

replaces _check_response with:

_wrap_response (implemented/overriden in jikan/aiojikan), which:
    parses the json (sync/async specific)
    calls (abstractjikan) _check_response (raises API error for failure)
    calls (abstractjikan) _add_jikan_metadata (to add the headers and jikan url)

```
>>> bebop = jikanpy.Jikan().anime(1)
>>> bebop["jikan_url"]
'https://api.jikan.moe/v3/anime/1'
>>> bebop["headers"]
{'Server': 'nginx/1.14.0 (Ubuntu)', 'Date': 'Fri, 30 Aug 2019 06:07:02 GMT', 'Content-Type': 'application/json', 'Content-Length': '2313', 'Connection': 'keep-alive', 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': '*', 'ETag': '"b88bef423688b42bc628035d65e4b0ee"', 'X-Request-Hash': 'request:anime:d6092f2422f084452c84555f17c7ba047e6998d3', 'X-Request-Cached': '1', 'X-Request-Cache-Ttl': '43176', 'Content-Encoding': 'gzip', 'Vary': 'Accept-Encoding', 'X-Cache-Status': 'HIT'}
```

also:
    updated the response type hints, to be requests.Response
    and aiohttp.ClientResponse instead of Any
    updated tests to match changes to _check_response

Couldnt find an logical way to split commits, so I just left it as this.

Let me know if anything should be changed, otherwise I can update the documentation.