### PR TITLE
allow letter param to be . for entries that start with punctuation

### DIFF
--- a/jikanpy/parameters.py
+++ b/jikanpy/parameters.py
@@ -82,7 +82,8 @@ SEARCH_PARAMS: Dict[
     "genre_exclude": (0, 1),
     "limit": "",
     "sort": ("ascending", "asc", "descending", "desc"),
-    "letter": tuple(string.ascii_lowercase),  # tuple of the lowercase letters
+    # tuple of lowercase letters and '.'
+    "letter": tuple(string.ascii_lowercase + "."),
 }
 
 # Possible seasons


### PR DESCRIPTION
Small PR that modifies the letter param to include `.`

The corresponding Jikan endpoint [isnt currently working](https://github.com/jikan-me/jikan-rest/issues/68), but this query:

`https://api.jikan.moe/v3/search/anime?q=&letter=.`

per [the url builder](https://github.com/jikan-me/jikan/blob/master/src/Request/Search/AnimeSearchRequest.php#L123), would result in this MAL query:

`https://myanimelist.net/anime.php?%s&c[]=a&c[]=b&c[]=c&c[]=f&c[]=d&c[]=e&c[]=g&letter=.`

which currently throws this error:

```

>>> Jikan().search("anime", query="", parameters={"letter": "."})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/jikanpy-3.1.2-py3.7.egg/jikanpy/jikan.py", line 55, in search
    url: str = self._get_search_url(search_type, query, page, parameters)
  File "/usr/local/lib/python3.7/site-packages/jikanpy-3.1.2-py3.7.egg/jikanpy/abstractjikan.py", line 139, in _get_search_url
    raise ClientException("The value is not valid")
jikanpy.exceptions.ClientException: The value is not valid
```

when it should be valid.